### PR TITLE
Add FindSubdivision(ByName|ByCode)

### DIFF
--- a/country.go
+++ b/country.go
@@ -59,17 +59,7 @@ func (c *Country) BorderingCountries() (countries []Country) {
 
 // SubDivisions returns the subdivisions for the given Country
 func (c *Country) SubDivisions() (subdivisions []SubDivision) {
-
-	query := New()
-
-	if res := query.Subdivisions[strings.ToLower(c.Alpha2)]; res != nil {
-
-		subdivisions = res
-
-	}
-
-	return
-
+	return c.subdivisions
 }
 
 // Codes contains various code representations

--- a/country.go
+++ b/country.go
@@ -28,7 +28,9 @@ type Country struct {
 	Coordinates
 
 	// Private
-	subdivisions []SubDivision
+	subdivisions      []SubDivision
+	nameToSubdivision map[string]SubDivision
+	codeToSubdivision map[string]SubDivision
 }
 
 // MeasurableCoordinates provides long/lat for country struct
@@ -60,6 +62,24 @@ func (c *Country) BorderingCountries() (countries []Country) {
 // SubDivisions returns the subdivisions for the given Country
 func (c *Country) SubDivisions() (subdivisions []SubDivision) {
 	return c.subdivisions
+}
+
+// FindSubdivisionByName fincs a country by given name
+func (c *Country) FindSubdivisionByName(name string) (result SubDivision, err error) {
+	s, exists := c.nameToSubdivision[strings.ToLower(name)]
+	if !exists {
+		return SubDivision{}, makeError("Could not find subdivision with name", name)
+	}
+	return s, nil
+}
+
+// FindSubdivisionByCode fincs a country by given code
+func (c *Country) FindSubdivisionByCode(code string) (result SubDivision, err error) {
+	s, exists := c.codeToSubdivision[strings.ToLower(code)]
+	if !exists {
+		return SubDivision{}, makeError("Could not find subdivision with code", code)
+	}
+	return s, nil
 }
 
 // Codes contains various code representations

--- a/query.go
+++ b/query.go
@@ -11,7 +11,6 @@ var queryInstance *Query
 // Query contains queries for countries, cities, etc.
 type Query struct {
 	Countries      map[string]Country
-	Subdivisions   map[string][]SubDivision
 	NameToAlpha2   map[string]string
 	Alpha3ToAlpha2 map[string]string
 }

--- a/setup.go
+++ b/setup.go
@@ -33,6 +33,15 @@ func NewFromPath(dataPath string) *Query {
 		for k := range queryInstance.Countries {
 			c := queryInstance.Countries[k]
 			c.subdivisions = subdivisions[strings.ToLower(c.Alpha2)]
+			c.nameToSubdivision = map[string]SubDivision{}
+			c.codeToSubdivision = map[string]SubDivision{}
+			for _, s := range c.subdivisions {
+				for _, n := range s.Names {
+					c.nameToSubdivision[strings.ToLower(n)] = s
+				}
+				c.nameToSubdivision[strings.ToLower(s.Name)] = s
+				c.codeToSubdivision[strings.ToLower(s.Code)] = s
+			}
 			queryInstance.Countries[k] = c
 		}
 

--- a/setup.go
+++ b/setup.go
@@ -23,11 +23,19 @@ func NewFromPath(dataPath string) *Query {
 
 	if queryInited == false {
 		queryInstance = &Query{
-			Countries:    populateCountries(dataPath),
-			Subdivisions: populateSubdivisions(dataPath),
+			Countries: populateCountries(dataPath),
 		}
+
 		queryInstance.NameToAlpha2 = populateNameIndex(queryInstance.Countries)
 		queryInstance.Alpha3ToAlpha2 = populateAlphaIndex(queryInstance.Countries)
+
+		subdivisions := populateSubdivisions(dataPath)
+		for k := range queryInstance.Countries {
+			c := queryInstance.Countries[k]
+			c.subdivisions = subdivisions[strings.ToLower(c.Alpha2)]
+			queryInstance.Countries[k] = c
+		}
+
 		queryInited = true
 	}
 

--- a/subdivision_test.go
+++ b/subdivision_test.go
@@ -14,4 +14,17 @@ func TestSubdivisions(t *testing.T) {
 
 	assert.Len(t, subd, 21)
 
+	found, err := se.FindSubdivisionByName(subd[0].Name)
+	assert.NoError(t, err)
+	assert.Equal(t, subd[0], found)
+
+	for _, n := range subd[0].Names {
+		found, err = se.FindSubdivisionByName(n)
+		assert.NoError(t, err)
+		assert.Equal(t, subd[0], found)
+	}
+
+	found, err = se.FindSubdivisionByCode(subd[0].Code)
+	assert.NoError(t, err)
+	assert.Equal(t, subd[0], found)
 }


### PR DESCRIPTION
This change does two things:

1. Optimizes the loading and storage of subdivisions so that they are owned by their respective countries.
    1. This prevents having to create a new instance of the package with each call to `Subdivisions()`, which incurred significant overhead.
2. Adds `FindSubdivisionByName` and `FindSubdivisionByCode`. This brings subdivisions on countries in line with the functionality offered by `FindCountryByName` and `FindCountryByAlpha`.