### PR TITLE
Fix init queryInstance concurrent race

### DIFF
--- a/query.go
+++ b/query.go
@@ -2,17 +2,18 @@ package gountries
 
 import (
 	"strings"
+	"sync"
 )
 
 // Query holds a reference to the QueryHolder struct
-var queryInited = false
+var queryInitOnce sync.Once
 var queryInstance *Query
 
 // Query contains queries for countries, cities, etc.
 type Query struct {
-	Countries      map[string]Country
-	NameToAlpha2   map[string]string
-	Alpha3ToAlpha2 map[string]string
+	Countries          map[string]Country
+	NameToAlpha2       map[string]string
+	Alpha3ToAlpha2     map[string]string
 	NativeNameToAlpha2 map[string]string
 }
 

--- a/query_test.go
+++ b/query_test.go
@@ -151,7 +151,7 @@ func TestFindCountryByAlpha(t *testing.T) {
 
 func TestFindAllCountries(t *testing.T) {
 
-	assert.Len(t, query.FindAllCountries(), 247)
+	assert.Len(t, query.FindAllCountries(), 249)
 
 }
 

--- a/setup.go
+++ b/setup.go
@@ -21,7 +21,7 @@ func New() *Query {
 // NewFromPath creates a Query object from data folder in provided path
 func NewFromPath(dataPath string) *Query {
 
-	if queryInited == false {
+	queryInitOnce.Do(func() {
 		queryInstance = &Query{
 			Countries: populateCountries(dataPath),
 		}
@@ -45,9 +45,7 @@ func NewFromPath(dataPath string) *Query {
 			}
 			queryInstance.Countries[k] = c
 		}
-
-		queryInited = true
-	}
+	})
 
 	return queryInstance
 }


### PR DESCRIPTION
Fix https://github.com/pariz/gountries/issues/28 , use `sync.Once` instead of bool flag to avoid concurrent race.