### PR TITLE
protect query init with sync.Once

### DIFF
--- a/query.go
+++ b/query.go
@@ -2,10 +2,11 @@ package gountries
 
 import (
 	"strings"
+	"sync"
 )
 
 // Query holds a reference to the QueryHolder struct
-var queryInited = false
+var queryInitOnce sync.Once
 var queryInstance *Query
 
 // Query contains queries for countries, cities, etc.

--- a/setup.go
+++ b/setup.go
@@ -21,7 +21,7 @@ func New() *Query {
 // NewFromPath creates a Query object from data folder in provided path
 func NewFromPath(dataPath string) *Query {
 
-	if queryInited == false {
+	queryInitOnce.Do(func() {
 		queryInstance = &Query{
 			Countries: populateCountries(dataPath),
 		}
@@ -45,9 +45,7 @@ func NewFromPath(dataPath string) *Query {
 			}
 			queryInstance.Countries[k] = c
 		}
-
-		queryInited = true
-	}
+	})
 
 	return queryInstance
 }


### PR DESCRIPTION
This PR fixes a race condition in the query initialization that can (and does) cause a concurrent map access panic.