### PR TITLE
Use correct path for go.mod

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -1,4 +1,4 @@
-module github.com/pbabbicola/gountries
+module github.com/pariz/gountries
 
 go 1.17
 


### PR DESCRIPTION
I created this go mod with `go mod init` and of course it autofilled the path with my fork's path. Sorry about that!